### PR TITLE
Prevent keyzen from capturing keypresses which include Ctrl/Alt/Cmd modifier keys

### DIFF
--- a/keyzen.js
+++ b/keyzen.js
@@ -36,6 +36,9 @@ function set_level(l) {
 
 function keyHandler(e) {
     var key = String.fromCharCode(e.which);
+    if (e.ctrlKey || e.altKey || e.metaKey) {
+    	return;
+    }
     if (data.chars.indexOf(key) > -1){
         e.preventDefault();
     }


### PR DESCRIPTION
Prevent keyzen from capturing keypresses which include Ctrl/Alt/Cmd modifier keys. These are likely browser/OS keyboard shortcuts and keyzen prevents the default event from firing, so this can be quite annoying in some browsers (Safari, I'm looking at you).
