### PR TITLE
Return early from key handler if key typed is not of interest

### DIFF
--- a/keyzen.js
+++ b/keyzen.js
@@ -60,11 +60,11 @@ function keyHandler(e) {
     start_stats();
 
     var key = String.fromCharCode(e.which);
-    if (e.ctrlKey || e.altKey || e.metaKey) {
-    	return;
-    }
     if (data.chars.indexOf(key) > -1){
         e.preventDefault();
+    }
+    else {
+    	return;
     }
     data.keys_hit += key;
     if(key == data.word[data.word_index]) {


### PR DESCRIPTION
This commit removes a clause which ignored keyboard events when a
modifier key was pressed (ctrl, alt, meta) and replaces it with a
clause which returns early if the key pressed is not of interest
to keyzen.

The previous behaviour prevented typing the '#' on UK Mac keyboards
which is typed with alt-3.

This fixes #7.
